### PR TITLE
投稿機能の修正

### DIFF
--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -11,6 +11,6 @@ class ArticleTag
     article = Article.create!(title: title, output: output, action: action, user_id: current_user.id)
     tag = Tag.create!(tag_name: tag_name)
     ArticleTagRelation.create!(article_id: article.id, tag_id: tag.id)
-    Habit.create!(action_id: action, user_id: current_user.id)
+    habit = Habit.create!(action: action, user_id: current_user.id)
   end
 end

--- a/app/models/article_tag.rb
+++ b/app/models/article_tag.rb
@@ -9,7 +9,8 @@ class ArticleTag
 
   def save(current_user)
     article = Article.create!(title: title, output: output, action: action, user_id: current_user.id)
-    tag = Tag.create!(tag_name: tag_name)
+    tag = Tag.where(tag_name: tag_name).first_or_initialize
+    tag.save
     ArticleTagRelation.create!(article_id: article.id, tag_id: tag.id)
     habit = Habit.create!(action: action, user_id: current_user.id)
   end

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -8,7 +8,7 @@
     <div>left</div>
     <% @habits.each do |habit| %>
       <div class="action" data-id=<%= habit.id %> data-check=<%= habit.checked %>>
-        <%= "#{habit.action_id}" %>
+        <%= "#{habit.action}" %>
       </div>
     <% end %>
 

--- a/db/migrate/20201128034607_create_habits.rb
+++ b/db/migrate/20201128034607_create_habits.rb
@@ -3,7 +3,7 @@ class CreateHabits < ActiveRecord::Migration[6.0]
     create_table :habits do |t|
       t.boolean :checked
       t.integer :user_id, foreign_key: true
-      t.integer :action_id, foreign_key: true
+      t.text :action, foreign_key: true
       t.timestamps
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -33,7 +33,7 @@ ActiveRecord::Schema.define(version: 2020_11_28_034607) do
   create_table "habits", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.boolean "checked"
     t.integer "user_id"
-    t.integer "action_id"
+    t.text "action"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end


### PR DESCRIPTION
what
タグが一意性のため同じタグでの登録ができなかった。
⇢first_or_initializeメソッドで修正した。
habitテーブルに保存する値を変更した。
⇢直接actionを保存するように修正した。
why
すでに存在するタグでの投稿ができるようにするため。
マイページでのactionの表示を行うため。